### PR TITLE
Python unittest job name unify to filename, different name is unnecessary

### DIFF
--- a/.github/workflows/python-unittest.yml
+++ b/.github/workflows/python-unittest.yml
@@ -3,7 +3,7 @@ name: Run all python unittests
 on: [push]
 
 jobs:
-  run-tests:
+  python-unittest:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

Resolve #27 
