### PR TITLE
` commit-msg` hook modify to no prefix verify for merge commit message (#57)

### DIFF
--- a/assets/commit-msg
+++ b/assets/commit-msg
@@ -12,7 +12,9 @@ msg_firstline=`cat "$1" | grep -v '^#' | grep -v '^\s*$' | sed -n -e '1p'`
 
 is_verify_ok=1
 
-if [ "`echo "$msg_firstline" | grep -E '^(Add|Mod|Fix): \S'`" = "" ]; then
+if [ "${1##*/}" = "MERGE_MSG" ]; then
+  echo "\033[1;36mPrefix verification skipped because of merge committing.\033[0m"
+elif [ "`echo "$msg_firstline" | grep -E '^(Add|Mod|Fix): \S'`" = "" ]; then
   echo "\033[1;31mInvalid prefix\033[0m" > /dev/stderr
   echo "\033[0;33m    Hint: Prefix must be 'Add:', 'Mod:' or 'Fix:'\033[0m" > /dev/stderr
   echo "\033[0;33m          And only 1 whitespace must be had between prefix and message body\033[0m" > /dev/stderr


### PR DESCRIPTION
## Description

Resolve #57

Script checked at my git (2.34.1) environment.
