### PR TITLE
 Indentation mistake in `audio.js` (#103)

### DIFF
--- a/src/static/packet_conv/audio.js
+++ b/src/static/packet_conv/audio.js
@@ -2,7 +2,7 @@
  * @file Encoding/decoding functions for audio packet
  *
  * More detail of packet protocol, see `designs/packet-protocol.md`
-*
+ *
  * Note: It tested only for monaural audio, multi channels is unsupported.
  *
  * @author aKuad


### PR DESCRIPTION
## Description

Close #103

## Checks

- [x] Lint or build passed
