### PR TITLE
 Docstring raises mistake in `audio_ndarray.py` (#104)

### DIFF
--- a/src/modules/packet_conv/audio_ndarray.py
+++ b/src/modules/packet_conv/audio_ndarray.py
@@ -80,9 +80,9 @@ def decode(raw_packet: bytes) -> tuple[np.ndarray, str, bytes]:
     tuple[numpy.ndarray, str, bytes]: Decoded data - Audio PCM in ``numpy.ndarray``, lane name and external bytes
 
   Raises:
-    * TypeError: If ``raw_packet`` is not ``bytes``
-    * ValueError: If ``raw_packet`` type ID bytes is not audio packet type ID
-    * ValueError: If ``raw_packet`` is too short (external bytes info is missing)
+    TypeError: If ``raw_packet`` is not ``bytes``
+    ValueError: If ``raw_packet`` type ID bytes is not audio packet type ID
+    ValueError: If ``raw_packet`` is too short (external bytes info is missing)
 
   """
   # Arguments type checking


### PR DESCRIPTION
## Description

Close #104

## Checks

- [x] Lint or build passed
