### PR TITLE
UUID4 as `lane_id` removing, manage it 0~255 value (#109)

### DIFF
--- a/src/modules/MixerTUI.py
+++ b/src/modules/MixerTUI.py
@@ -10,7 +10,6 @@ Author:
 
 import curses
 from curses import window
-from uuid import uuid4
 from dataclasses import dataclass
 
 
@@ -73,7 +72,7 @@ class MixerTUI:
 
     """
     if lane_id == None:
-      lane_id = uuid4().int
+      lane_id = self.__lookup_available_lane_id()
 
     name_adj = (name + "   ")[:3] # Set 3 length, empty fill with spaces, over will cut
     self.__lanes[lane_id] = MixerTUILane(self.__FADER_WIDTH // 2, name_adj)
@@ -202,3 +201,20 @@ class MixerTUI:
     lane_index = self.__lane_id2index(lane_id)
     return (lane_index * 2) + 1
     # * 2 for meter view index, + 1 for console head offset
+
+
+  def __lookup_available_lane_id(self) -> int:
+    """Return available smallest lane ID
+
+    Returns:
+      int: Available smallest lane ID (0~255)
+
+    Raises:
+      BufferError: If lane count already reached to 256
+
+    """
+    if len(self.__lanes) >= 255:
+      raise BufferError("Already reached to maximum lane count")
+    
+    available_ids = set(range(255)) - set(self.__lanes.keys())
+    return min(available_ids)

--- a/src/modules/MixerTUI.py
+++ b/src/modules/MixerTUI.py
@@ -215,6 +215,6 @@ class MixerTUI:
     """
     if len(self.__lanes) >= 255:
       raise BufferError("Already reached to maximum lane count")
-    
+
     available_ids = set(range(255)) - set(self.__lanes.keys())
     return min(available_ids)

--- a/src/tests/py_unittest/packet_conv/Test_volume_modify.py
+++ b/src/tests/py_unittest/packet_conv/Test_volume_modify.py
@@ -22,8 +22,6 @@ sys.path.append(Path(__file__).absolute().parent.parent.parent.__str__())
 
 import unittest
 
-from uuid import uuid4
-
 from modules.packet_conv import volume_modify
 
 


### PR DESCRIPTION
## Description

Fix #109 

## Checks

- [x] Created or fixed test code
- [x] Tests can cover all features
- ~~if can't: test support utilities added~~
- [x] All tests passed
