### PR TITLE
Docstring raises mistake in `audio_aseg.py` (#115)

### DIFF
--- a/src/modules/packet_conv/audio_aseg.py
+++ b/src/modules/packet_conv/audio_aseg.py
@@ -76,9 +76,9 @@ def decode(raw_packet: bytes) -> tuple[AudioSegment, str, bytes]:
     tuple[pydub.AudioSegment, str, bytes]: Decoded data - Audio PCM in ``pydub.AudioSegment``, lane name and external bytes
 
   Raises:
-    * TypeError: If ``raw_packet`` is not ``bytes``
-    * ValueError: If ``raw_packet`` type ID bytes is not audio packet type ID
-    * ValueError: If ``raw_packet`` is too short (external bytes info is missing)
+    TypeError: If ``raw_packet`` is not ``bytes``
+    ValueError: If ``raw_packet`` type ID bytes is not audio packet type ID
+    ValueError: If ``raw_packet`` is too short (external bytes info is missing)
 
   """
   # Arguments type checking


### PR DESCRIPTION
…_conv/audio_aseg.py`

## Description

Close #115

## Checks

- [x] Lint or build passed
