### PR TITLE
 Unnecessary `if` for returning equal compersion result (#142)

### DIFF
--- a/src/static/packet_conv/audio.js
+++ b/src/static/packet_conv/audio.js
@@ -139,8 +139,5 @@ export function is_audio_packet(raw_packet) {
     throw new RangeError("Empty array passed");
   }
 
-  if(raw_packet[0] === AUDIO_PACKET_TYPE_ID || raw_packet[0] === SILENT_AUDIO_PACKET_TYPE_ID)
-    return true;
-  else
-    return false;
+  return (raw_packet[0] === AUDIO_PACKET_TYPE_ID || raw_packet[0] === SILENT_AUDIO_PACKET_TYPE_ID);
 }


### PR DESCRIPTION
## Description

Fix #142

## Checks

- [x] Made no changes to feature
  - If any changes, post as feature add/fix PR
- [x] All tests passed
