### PR TITLE
No documentation (docstring) in `AUDIO_PARAM.py` (#148)

### DIFF
--- a/src/modules/packet_conv/AUDIO_PARAM.py
+++ b/src/modules/packet_conv/AUDIO_PARAM.py
@@ -1,4 +1,12 @@
 # coding: UTF-8
+"""Audio data parameters at this system
+
+It for avoid magic-number coding. And keep same parameters at all modules.
+
+Author:
+  aKuad
+
+"""
 
 SAMPLE_RATE = 44100
 DTYPE = "int16"


### PR DESCRIPTION
## Description

Close #148

## Checks

- [x] Lint or build passed
